### PR TITLE
setup.py: Use sys.executable

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -144,7 +144,7 @@ def get_djvulibre_version():
     return distutils.version.LooseVersion(version)
 
 def get_cython_version():
-    cmdline = ['python', '-m', 'cython', '--version']
+    cmdline = [sys.executable, '-m', 'cython', '--version']
     cmd = ipc.Popen(cmdline, stdout=ipc.PIPE, stderr=ipc.STDOUT)
     stdout, stderr = cmd.communicate()
     if not isinstance(stdout, str):


### PR DESCRIPTION
Literal `python` could be missing or the wrong python.

Fixes https://github.com/jwilk/python-djvulibre/issues/10